### PR TITLE
switch image list to simple container

### DIFF
--- a/src/ImageList.tsx
+++ b/src/ImageList.tsx
@@ -1,46 +1,26 @@
-import { Grid } from "semantic-ui-react";
 import MetadataStore from "./MetadataStore";
 import React from 'react';
 
 const ms = new MetadataStore();
 
 const ImageList = () => {
-    let rowChunks = [[<Grid.Column></Grid.Column>]];
-    rowChunks.shift(); // NOTE: this is a hack because I don't know how to type the above array without putting something in it
+    let tiles = [] as JSX.Element[];
 
     ms.metadata.forEach((imgMetadata, index) => {
         const imgUrl = `/static/images/${imgMetadata.subpath}_thumbnail.jpg`;
-        const divStyle = {
-            display: "flex", 
-            alignItems: "center", 
-            justifyContent: "center"
-        } as React.CSSProperties;
-
-        let imageColumn = <Grid.Column key={index}>
-        <div style={{textAlign: "center"}}>
-            <div style={divStyle}>
-                <a href={"/i/" + imgMetadata.subpath}><img alt={imgMetadata.title} src={imgUrl} /></a>
-            </div>
+        let imageColumn =
+        <div key={index} style={{textAlign: "center", display: "inline-block", padding: "1em" }}>
+            <a href={"/i/" + imgMetadata.subpath}><img alt={imgMetadata.title} src={imgUrl} /></a>
             <div>
                 <label>{imgMetadata.title}</label>
             </div>
-        </div>
-        </Grid.Column>;
-
-        if (index % 3 === 0) {
-            rowChunks.push([ imageColumn ]);
-        } else {
-            rowChunks[rowChunks.length - 1].push(imageColumn);
-        }
+        </div>;
+        tiles.push(imageColumn);
     });
 
-    let rows = rowChunks.map((rowChunk, rowIndex) => {
-        return <Grid.Row key={rowIndex} columns={3}>{ rowChunk }</Grid.Row>;
-    });
-
-    return <Grid>
-        { rows }
-    </Grid>;
+    return <>
+        {tiles}
+    </>;
 }
 
 export { ImageList };


### PR DESCRIPTION
After reading through the documentation of _Grid_ it seemed like it wasn't a good fit for a responsive layout where we want things to naturally wrap around. I've removed it and instead just use the container outside of _ImageList_. 

It's also a lot simpler. 

**Wide Screen**
![wide_screen](https://user-images.githubusercontent.com/786471/107284914-4afdc500-6a13-11eb-9b2a-0577714092f2.png)

**Narrow Screen (Phone)**
![narrow_screen](https://user-images.githubusercontent.com/786471/107284939-53560000-6a13-11eb-9c25-be3adcda7a4b.png)
