### PR TITLE
hide SVG until image is loaded, add unprocessed images for warp-core-…

### DIFF
--- a/src/BusyImage.tsx
+++ b/src/BusyImage.tsx
@@ -76,6 +76,7 @@ const BusyImage = (props: BusyImageProps) => {
   let [svgWidth, setSVGWidth] = useState("1920px");
   let [svgHeight, setSVGHeight] = useState("1080px");
   let labelRef= useRef<HTMLDivElement>(null);
+  let [imageLoaded, setImageLoaded] = useState(false);
 
   const mouseMovedCallback = useCallback((ev: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
     const rect = ev.currentTarget.getBoundingClientRect();
@@ -98,6 +99,7 @@ const BusyImage = (props: BusyImageProps) => {
   const onImageLoad = (event: SyntheticEvent<HTMLImageElement,Event>) => {
     setSVGWidth(event.currentTarget.width + "px");
     setSVGHeight(event.currentTarget.height + "px");
+    setImageLoaded(true);
   };
 
   const allSVGShapes: (JSX.Element | null)[] = Object.keys(partNames).map((partName, partIndex) => {
@@ -168,9 +170,11 @@ const BusyImage = (props: BusyImageProps) => {
   return <div onMouseMove={ mouseMovedCallback } style={imgContainerStyle}>
     <img alt={props.metadata.title} src={imgUrl} onLoad={onImageLoad} />
     <div style={overlayStyle}>
-    <svg style={svgStyle}>
-      { allSVGShapes }
-    </svg>
+      {imageLoaded && 
+        <svg style={svgStyle}>
+          { allSVGShapes }
+        </svg>
+      }
       {
         partLabel
       }


### PR DESCRIPTION
…cafe

Added image and thumbnail for warp-core-cafe but have not processed
imageLoaded boolean added to hide SVG until image is loaded

fixes #13 
fixes #15 

![image](https://user-images.githubusercontent.com/14046088/107681888-84714300-6c54-11eb-8867-e0feb089fb03.png)
