### PR TITLE
prevent label mouse events

### DIFF
--- a/src/BusyImage.tsx
+++ b/src/BusyImage.tsx
@@ -135,7 +135,8 @@ const BusyImage = (props: BusyImageProps) => {
     background: "rgba(0,0,0,0.2)",
     padding: "5px",
     whiteSpace: "nowrap",
-    float: "right"
+    float: "right",
+    pointerEvents: "none"
   } as React.CSSProperties;
   const [name,origin] = parseNameOrigin(hoveredPartName);
   let partLabel = (


### PR DESCRIPTION
With the labels closer to the cursor it's more easily possible to mouse over the label accidentally, which starts stealing focus. The fix is to ignore all mouse events on the label. 

Fixes #27 